### PR TITLE
deploy pull requests to external repository

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -21,5 +21,13 @@ jobs:
           # extended: true
 
       - name: Build website
-        run: hugo  # we should not use the --minify option with our theme
+        run: hugo --baseURL=https://wiki.mate-desktop.dev/
 
+      - name: Deploy website
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: mate-desktop/mate-wiki-preview
+          publish_branch: gh-pages
+          publish_dir: ./public
+          cname: wiki.mate-desktop.dev


### PR DESCRIPTION
make use of the old https://github.com/mate-desktop-legacy-archive/mate-wiki-preview to get a live preview of the wiki for PRs. We may need to setup a deploy key, see https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-deploy-to-external-repository-external_repository and https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-ssh-private-key-deploy_key