### PR TITLE
Update installation.md

### DIFF
--- a/content/en/introduction/installation.md
+++ b/content/en/introduction/installation.md
@@ -76,7 +76,7 @@ If you have authorization problems (e.g. when mounting disks), try adding `dbus-
 {{< tab "Fedora" >}}
 Install the MATE Desktop Environment with
 
-- `sudo dnf install mate-desktop-environment`
+- `sudo dnf group install mate-desktop`
 {{< /tab >}}
 
 {{< tab "Arch/Manjaro" >}}


### PR DESCRIPTION
In all of my recent installations on Fedora Server Edition I've needed to use dnf group install.

mate-desktop-environment is not found in the default repositories.